### PR TITLE
[wsc-017] 로그인 정보 바탕으로 함께해요 글쓰기 작업

### DIFF
--- a/src/components/AuthLogin/index.tsx
+++ b/src/components/AuthLogin/index.tsx
@@ -3,8 +3,8 @@ import { css } from '@emotion/react'
 import { Common } from 'styles/common'
 
 export default function AuthLogin() {
-  const kakaoLogin = () => (location.href = 'https://wellseecoding.com/oauth2/authorization/kakao')
-  const naverLogin = () => (location.href = 'https://wellseecoding.com/oauth2/authorization/naver')
+  const kakaoLogin = () => (location.href = 'https://api.wellseecoding.com/oauth2/authorization/kakao')
+  const naverLogin = () => (location.href = 'https://api.wellseecoding.com/oauth2/authorization/naver')
 
   return (
     <div css={authLoginButton}>

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -72,10 +72,16 @@ const TogetherWrite = () => {
       setHashtag('')
 
       if (process.browser) {
+        // const $HashWrapParent = document.querySelector('.HashWrap')
         const $HashWrap = document.querySelector('.HashWrapInner')
         // HashWrap 노드의 자식 노드를 모두 삭제한다
         $HashWrap?.remove()
+        // while ($HashWrap?.hasChildNodes()) {
+        //   $HashWrap.remove()
+        // }
+        console.log('자식이 있나요?', $HashWrap?.hasChildNodes())
       }
+      setReady(false)
     },
     [title, period, schedule, qualification, peopleNum, hashArr]
   )
@@ -87,6 +93,7 @@ const TogetherWrite = () => {
         const $HashWrapParent = document.querySelector('.HashWrap')
         // 해시태그가 될 div
         const $HashWrap = document.createElement('div')
+        // HashWrapInner에 대한 스타일은 사전에 emotion을 통해 지정한다
         $HashWrap.className = 'HashWrapInner'
         /* 클릭시 부모 div에서 해당 요소 삭제*/
         $HashWrap.addEventListener('click', () => $HashWrapParent?.removeChild($HashWrap))
@@ -94,7 +101,7 @@ const TogetherWrite = () => {
         /* enter 키 코드 :13 */
         if (e.keyCode === 13 && e.target.value.trim() !== '') {
           console.log('Enter Key 입력됨!', e.target.value)
-          $HashWrap.innerHTML = e.target.value
+          $HashWrap.innerHTML = '#' + e.target.value
           $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
           setHashArr((hashArr) => [...hashArr, hashtag])
           setHashtag('')

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -118,7 +118,7 @@ const TogetherWrite = () => {
 ex) 프론트 n명, 백 n명
 기획자나 디자이너가 있을 경우 명시"
           />
-          <div style={{ display: 'flex' }} className="HashWrap">
+          <div className="HashWrap" css={hashDivrap}>
             <input
               className="HashInput"
               type="text"
@@ -200,16 +200,44 @@ const writeForm = css`
       margin: 20px 0px;
     }
   }
+`
+
+const hashDivrap = css`
+  margin-top: 24px;
+  color: rgb(52, 58, 64);
+  font-size: 1.125rem;
+  display: flex;
+  flex-wrap: wrap;
+  letter-spacing: -0.6px;
+  color: #444241;
+  border-bottom: 1.6px solid ${Common.colors.gray04};
+  padding: 2px 2px 8px 2px;
 
   .HashWrapInner {
+    margin-top: 5px;
     background: #ffeee7;
     border-radius: 56px;
     padding: 8px 12px;
     color: #ff6e35;
-    display: inline-block;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     font-weight: bold;
     font-size: 1.4rem;
     line-height: 20px;
+    margin-right: 5px;
+  }
+
+  .HashInput {
+    width: auto;
+    margin: 10px;
+    display: inline-flex;
+    outline: none;
+    cursor: text;
+    line-height: 2rem;
+    margin-bottom: 0.75rem;
+    min-width: 8rem;
+    border: none;
   }
 `
 

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -2,9 +2,7 @@ import FootButton, { FootButtonType } from 'components/Common/FootButton'
 import TogetherBack from 'components/Common/Header/Back'
 import { css } from '@emotion/react'
 import { Common } from 'styles/common'
-import { useCallback } from 'react'
-import { useState } from 'react'
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 const TogetherWrite = () => {
   const [title, setTitle] = useState<string | ''>('')

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -2,19 +2,94 @@ import FootButton, { FootButtonType } from 'components/Common/FootButton'
 import TogetherBack from 'components/Common/Header/Back'
 import { css } from '@emotion/react'
 import { Common } from 'styles/common'
+import { useCallback } from 'react'
+
+import { useState } from 'react'
+import { useEffect } from 'react'
 
 const TogetherWrite = () => {
+  const [title, setTitle] = useState<string | ''>('')
+  const [period, setPeriod] = useState<string | ''>('')
+  const [schedule, setSchedule] = useState<string | ''>('')
+  const [qualification, setQualification] = useState<string | ''>('')
+  const [peopleNum, setPeopleNum] = useState<string | ''>('')
+  const [hashtag, setHashtag] = useState<string | ''>('')
+
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    if (
+      title.length &&
+      period.length &&
+      schedule.length &&
+      qualification.length &&
+      peopleNum.length &&
+      hashtag.length
+    ) {
+      setReady(true)
+    } else {
+      setReady(false)
+    }
+  }, [title, period, schedule, qualification, peopleNum, hashtag])
+
+  const onChangeTitle = useCallback((e) => {
+    setTitle(e.target.value)
+  }, [])
+
+  const onChangePeriod = useCallback((e) => {
+    setPeriod(e.target.value)
+  }, [])
+
+  const onChangeSchedule = useCallback((e) => {
+    setSchedule(e.target.value)
+  }, [])
+
+  const onChangeQualification = useCallback((e) => {
+    setQualification(e.target.value)
+  }, [])
+
+  const onChangePeopleNum = useCallback((e) => {
+    setPeopleNum(e.target.value)
+  }, [])
+
+  const onChangeHashtag = useCallback((e) => {
+    setHashtag(e.target.value)
+  }, [])
+
+  const onSubmit = useCallback(
+    (e) => {
+      e.preventDefault()
+      alert(
+        `모임지역:${title}\n작업기간:${period}\n일정:${schedule}\n자격요건:${qualification}\n모집인원:${peopleNum}\n해시태그:${hashtag}`
+      )
+      setTitle('')
+      setPeriod('')
+      setSchedule('')
+      setQualification('')
+      setPeopleNum('')
+      setHashtag('')
+    },
+    [title, period, schedule, qualification, peopleNum, hashtag]
+  )
+
   return (
     <>
       <TogetherBack text="모임 글쓰기" />
       <main css={writeWrap}>
-        <form css={writeForm}>
-          <input type="text" placeholder="[모임지역]모임명" />
-          <input type="text" placeholder="작업기간 (데드라인)" />
-          <input type="text" placeholder="일정 (주 몇회, 온라인/오프라인)" />
+        <form css={writeForm} onSubmit={onSubmit}>
+          <input type="text" value={title} onChange={onChangeTitle} placeholder="[모임지역]모임명" />
+          <input type="text" value={period} onChange={onChangePeriod} placeholder="작업기간 (데드라인)" />
+          <input
+            type="text"
+            value={schedule}
+            onChange={onChangeSchedule}
+            placeholder="일정 (주 몇회, 온라인/오프라인)"
+          />
           <textarea
             rows={5}
             cols={5}
+            value={qualification}
+            onChange={onChangeQualification}
             placeholder="자격요건(취준/경력, 사용언어 등등)
           ex) 같은 취준생 / 경력 2년 이상
           프로젝트 경험 n번 이상
@@ -24,16 +99,22 @@ const TogetherWrite = () => {
           <textarea
             rows={5}
             cols={5}
+            value={peopleNum}
+            onChange={onChangePeopleNum}
             placeholder="모집인원 (분야별/몇명)
 ex) 프론트 n명, 백 n명
 기획자나 디자이너가 있을 경우 명시"
           />
 
-          <input type="text" placeholder="해시태그 입력" />
+          <input type="text" value={hashtag} onChange={onChangeHashtag} placeholder="해시태그 입력" />
         </form>
 
         <div css={footButtonWrapper}>
-          <FootButton type="submit" footButtonType={FootButtonType.DISABLE}>
+          <FootButton
+            type="submit"
+            footButtonType={ready ? FootButtonType.ACTIVATION : FootButtonType.DISABLE}
+            onClick={onSubmit}
+          >
             다음
           </FootButton>
         </div>

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -3,7 +3,6 @@ import TogetherBack from 'components/Common/Header/Back'
 import { css } from '@emotion/react'
 import { Common } from 'styles/common'
 import { useCallback } from 'react'
-
 import { useState } from 'react'
 import { useEffect } from 'react'
 
@@ -17,20 +16,16 @@ const TogetherWrite = () => {
 
   const [ready, setReady] = useState(false)
 
+  const dataArr = [title, period, schedule, qualification, peopleNum, hashtag]
+
   useEffect(() => {
-    if (
-      title.length &&
-      period.length &&
-      schedule.length &&
-      qualification.length &&
-      peopleNum.length &&
-      hashtag.length
-    ) {
-      setReady(true)
-    } else {
-      setReady(false)
-    }
-  }, [title, period, schedule, qualification, peopleNum, hashtag])
+    checkDataLength()
+  }, [dataArr])
+
+  /* dataArr의 문자열이 존재한다면 > 버튼을 활성화 */
+  const checkDataLength = useCallback(() => {
+    if (dataArr.every((data) => data?.length > 5) === true) setReady(true)
+  }, [dataArr])
 
   const onChangeTitle = useCallback((e) => {
     setTitle(e.target.value)
@@ -72,6 +67,24 @@ const TogetherWrite = () => {
     [title, period, schedule, qualification, peopleNum, hashtag]
   )
 
+  const onKeyUp = useCallback((e) => {
+    if (process.browser) {
+      // 부모 div
+      const $HashWrapParent = document.querySelector('.HashWrap')
+      // 해시태그가 될 div
+      const $HashWrap = document.createElement('div')
+      $HashWrap.className = 'HashWrapInner'
+
+      /* enter 키 코드 :13 */
+      if (e.keyCode === 13 && e.target.value.trim() !== '') {
+        console.log('Enter Key 입력됨!', e.target.value)
+        $HashWrap.innerHTML = e.target.value
+        $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
+        e.target.value = ''
+      }
+    }
+  }, [])
+
   return (
     <>
       <TogetherBack text="모임 글쓰기" />
@@ -105,8 +118,16 @@ const TogetherWrite = () => {
 ex) 프론트 n명, 백 n명
 기획자나 디자이너가 있을 경우 명시"
           />
-
-          <input type="text" value={hashtag} onChange={onChangeHashtag} placeholder="해시태그 입력" />
+          <div style={{ display: 'flex' }} className="HashWrap">
+            <input
+              className="HashInput"
+              type="text"
+              value={hashtag}
+              onChange={onChangeHashtag}
+              onKeyUp={onKeyUp}
+              placeholder="해시태그 입력"
+            />
+          </div>
         </form>
 
         <div css={footButtonWrapper}>
@@ -178,6 +199,17 @@ const writeForm = css`
       border-bottom: 1px solid #bcbcbc;
       margin: 20px 0px;
     }
+  }
+
+  .HashWrapInner {
+    background: #ffeee7;
+    border-radius: 56px;
+    padding: 8px 12px;
+    color: #ff6e35;
+    display: inline-block;
+    font-weight: bold;
+    font-size: 1.4rem;
+    line-height: 20px;
   }
 `
 

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -73,13 +73,11 @@ const TogetherWrite = () => {
 
       if (process.browser) {
         // const $HashWrapParent = document.querySelector('.HashWrap')
-        const $HashWrap = document.querySelector('.HashWrapInner')
+        const $HashWrapOuter = document.querySelector('.HashWrapOuter')
+        // const $HashWrap = document.querySelector('.HashWrapInner')
         // HashWrap 노드의 자식 노드를 모두 삭제한다
-        $HashWrap?.remove()
-        // while ($HashWrap?.hasChildNodes()) {
-        //   $HashWrap.remove()
-        // }
-        console.log('자식이 있나요?', $HashWrap?.hasChildNodes())
+        $HashWrapOuter?.remove()
+        console.log('자식이 있나요?', $HashWrapOuter?.hasChildNodes())
       }
       setReady(false)
     },
@@ -88,21 +86,26 @@ const TogetherWrite = () => {
 
   const onKeyUp = useCallback(
     (e) => {
+      // SSR 시에 브라우저의 document가 로드되기 전에 동작되므로
+      // process.browser 라는 코드를 통해 브라우저가 정상 로드된 이후 코드를 사용할 수 있도록 만든다
       if (process.browser) {
-        // 부모 div
-        const $HashWrapParent = document.querySelector('.HashWrap')
         // 해시태그가 될 div
-        const $HashWrap = document.createElement('div')
-        // HashWrapInner에 대한 스타일은 사전에 emotion을 통해 지정한다
-        $HashWrap.className = 'HashWrapInner'
+        const $HashWrapOuter = document.querySelector('.HashWrapOuter')
+        const $HashWrapInner = document.createElement('div')
+        $HashWrapInner.className = 'HashWrapInner'
         /* 클릭시 부모 div에서 해당 요소 삭제*/
-        $HashWrap.addEventListener('click', () => $HashWrapParent?.removeChild($HashWrap))
+        $HashWrapInner.addEventListener('click', () => {
+          $HashWrapOuter?.removeChild($HashWrapInner)
+          console.log($HashWrapInner.innerHTML)
+          /*  hashArr state 배열에서 해당 hashTag를 삭제 */
+          setHashArr(hashArr.filter((hashtag) => hashtag))
+        })
 
         /* enter 키 코드 :13 */
         if (e.keyCode === 13 && e.target.value.trim() !== '') {
           console.log('Enter Key 입력됨!', e.target.value)
-          $HashWrap.innerHTML = '#' + e.target.value
-          $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
+          $HashWrapInner.innerHTML = '#' + e.target.value
+          $HashWrapOuter?.appendChild($HashWrapInner)
           setHashArr((hashArr) => [...hashArr, hashtag])
           setHashtag('')
         }
@@ -145,6 +148,7 @@ ex) 프론트 n명, 백 n명
 기획자나 디자이너가 있을 경우 명시"
           />
           <div className="HashWrap" css={hashDivrap}>
+            <div className="HashWrapOuter"></div>
             <input
               className="HashInput"
               type="text"
@@ -238,6 +242,11 @@ const hashDivrap = css`
   color: #444241;
   border-bottom: 1.6px solid ${Common.colors.gray04};
   padding: 2px 2px 8px 2px;
+
+  .HashWrapOuter {
+    display: flex;
+    flex-wrap: wrap;
+  }
 
   .HashWrapInner {
     margin-top: 5px;

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -25,7 +25,7 @@ const TogetherWrite = () => {
   }, [dataArr])
 
   useEffect(() => {
-    hashArr.length ? console.log(hashArr) : console.log('x')
+    hashArr.length && console.log(hashArr)
   }, [hashArr])
 
   /* dataArr의 문자열이 존재한다면 > 버튼을 활성화 */
@@ -72,12 +72,9 @@ const TogetherWrite = () => {
       setHashtag('')
 
       if (process.browser) {
-        // const $HashWrapParent = document.querySelector('.HashWrap')
         const $HashWrapOuter = document.querySelector('.HashWrapOuter')
-        // const $HashWrap = document.querySelector('.HashWrapInner')
         // HashWrap 노드의 자식 노드를 모두 삭제한다
         $HashWrapOuter?.remove()
-        console.log('자식이 있나요?', $HashWrapOuter?.hasChildNodes())
       }
       setReady(false)
     },
@@ -96,14 +93,12 @@ const TogetherWrite = () => {
         /* 클릭시 부모 div에서 해당 요소 삭제*/
         $HashWrapInner.addEventListener('click', () => {
           $HashWrapOuter?.removeChild($HashWrapInner)
-          console.log($HashWrapInner.innerHTML)
           /*  hashArr state 배열에서 해당 hashTag를 삭제 */
           setHashArr(hashArr.filter((hashtag) => hashtag))
         })
 
         /* enter 키 코드 :13 */
         if (e.keyCode === 13 && e.target.value.trim() !== '') {
-          console.log('Enter Key 입력됨!', e.target.value)
           $HashWrapInner.innerHTML = '#' + e.target.value
           $HashWrapOuter?.appendChild($HashWrapInner)
           setHashArr((hashArr) => [...hashArr, hashtag])
@@ -111,7 +106,7 @@ const TogetherWrite = () => {
         }
       }
     },
-    [hashtag]
+    [hashtag, hashArr]
   )
 
   return (

--- a/src/pages/together/write/index.tsx
+++ b/src/pages/together/write/index.tsx
@@ -13,18 +13,24 @@ const TogetherWrite = () => {
   const [qualification, setQualification] = useState<string | ''>('')
   const [peopleNum, setPeopleNum] = useState<string | ''>('')
   const [hashtag, setHashtag] = useState<string | ''>('')
+  // 해시태그를 담을 배열
+  const [hashArr, setHashArr] = useState<string[] | []>([])
 
   const [ready, setReady] = useState(false)
 
-  const dataArr = [title, period, schedule, qualification, peopleNum, hashtag]
+  const dataArr = [title, period, schedule, qualification, peopleNum, hashArr]
 
   useEffect(() => {
     checkDataLength()
   }, [dataArr])
 
+  useEffect(() => {
+    hashArr.length ? console.log(hashArr) : console.log('x')
+  }, [hashArr])
+
   /* dataArr의 문자열이 존재한다면 > 버튼을 활성화 */
   const checkDataLength = useCallback(() => {
-    if (dataArr.every((data) => data?.length > 5) === true) setReady(true)
+    if (dataArr.every((data) => data?.length) === true) setReady(true)
   }, [dataArr])
 
   const onChangeTitle = useCallback((e) => {
@@ -55,35 +61,48 @@ const TogetherWrite = () => {
     (e) => {
       e.preventDefault()
       alert(
-        `모임지역:${title}\n작업기간:${period}\n일정:${schedule}\n자격요건:${qualification}\n모집인원:${peopleNum}\n해시태그:${hashtag}`
+        `모임지역:${title}\n작업기간:${period}\n일정:${schedule}\n자격요건:${qualification}\n모집인원:${peopleNum}\n해시태그:${hashArr}`
       )
       setTitle('')
       setPeriod('')
       setSchedule('')
       setQualification('')
       setPeopleNum('')
+      setHashArr([])
       setHashtag('')
+
+      if (process.browser) {
+        const $HashWrap = document.querySelector('.HashWrapInner')
+        // HashWrap 노드의 자식 노드를 모두 삭제한다
+        $HashWrap?.remove()
+      }
     },
-    [title, period, schedule, qualification, peopleNum, hashtag]
+    [title, period, schedule, qualification, peopleNum, hashArr]
   )
 
-  const onKeyUp = useCallback((e) => {
-    if (process.browser) {
-      // 부모 div
-      const $HashWrapParent = document.querySelector('.HashWrap')
-      // 해시태그가 될 div
-      const $HashWrap = document.createElement('div')
-      $HashWrap.className = 'HashWrapInner'
+  const onKeyUp = useCallback(
+    (e) => {
+      if (process.browser) {
+        // 부모 div
+        const $HashWrapParent = document.querySelector('.HashWrap')
+        // 해시태그가 될 div
+        const $HashWrap = document.createElement('div')
+        $HashWrap.className = 'HashWrapInner'
+        /* 클릭시 부모 div에서 해당 요소 삭제*/
+        $HashWrap.addEventListener('click', () => $HashWrapParent?.removeChild($HashWrap))
 
-      /* enter 키 코드 :13 */
-      if (e.keyCode === 13 && e.target.value.trim() !== '') {
-        console.log('Enter Key 입력됨!', e.target.value)
-        $HashWrap.innerHTML = e.target.value
-        $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
-        e.target.value = ''
+        /* enter 키 코드 :13 */
+        if (e.keyCode === 13 && e.target.value.trim() !== '') {
+          console.log('Enter Key 입력됨!', e.target.value)
+          $HashWrap.innerHTML = e.target.value
+          $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
+          setHashArr((hashArr) => [...hashArr, hashtag])
+          setHashtag('')
+        }
       }
-    }
-  }, [])
+    },
+    [hashtag]
+  )
 
   return (
     <>
@@ -226,6 +245,7 @@ const hashDivrap = css`
     font-size: 1.4rem;
     line-height: 20px;
     margin-right: 5px;
+    cursor: pointer;
   }
 
   .HashInput {


### PR DESCRIPTION
# 이슈 번호
#14 

## 📄 PR 내용
- 백엔드 서버에서 넘겨받는 소셜 로그인 정보(토큰)를 저장합니다
- 함께해요 페이지의 글쓰기 기능을 구현합니다
- 글쓴 내용을 바탕으로 백엔드서버에 요청을 보내고 결과를 확인합니다

## 📝 상세 내용

- 함께해요 예상 흐름도 (분석)

<img width="600" src="https://user-images.githubusercontent.com/54658162/131250745-83dd17d5-5036-42cb-81a6-699dd38c43f6.jpg"/>

<img width="600" src="https://user-images.githubusercontent.com/54658162/131250763-ac41fe53-03d1-43a1-8b10-9fff35993e0d.jpg"/>

- 해시태그 부분 (분석)

https://user-images.githubusercontent.com/54658162/131250773-06c0512d-46a9-44f5-b71a-a1b10d2da20a.mov

1. todolist 처럼 enter key event를 바탕으로 태그 생성
2. 클릭시 해당 태그 삭제


https://user-images.githubusercontent.com/54658162/131285656-419b914c-7094-446b-838b-e735ef532f99.mov

3. div 태그 내부에서 input 입력받음
4. onsubmit이 아닌, onKeydown 과 이벤트를 사용하여 엔터키를 입력시, 태그 생성
5. css는 미리 지정해준 것으로 보임

## ✔ 체크리스트

- [x] 요구사항에 따른 상세내용에 적힌 기능 구현

## 결과물 (1차)


https://user-images.githubusercontent.com/54658162/131345383-93237b40-347a-443a-b445-141a7918671d.mov

태그 1개 이상 작성할 시, 로직 구조에 따라 unshift()로 들어가게 됨

```js
  const onKeyUp = useCallback(
    (e) => {
      if (process.browser) {
        // 부모 div
        const $HashWrapParent = document.querySelector('.HashWrap')
        // 해시태그가 될 div
        const $HashWrap = document.createElement('div')
        // HashWrapInner에 대한 스타일은 사전에 emotion을 통해 지정한다
        $HashWrap.className = 'HashWrapInner'
        /* 클릭시 부모 div에서 해당 요소 삭제*/
        $HashWrap.addEventListener('click', () => $HashWrapParent?.removeChild($HashWrap))

        /* enter 키 코드 :13 */
        if (e.keyCode === 13 && e.target.value.trim() !== '') {
          console.log('Enter Key 입력됨!', e.target.value)
          $HashWrap.innerHTML = '#' + e.target.value
          $HashWrapParent?.insertBefore($HashWrap, $HashWrapParent.firstChild)
          setHashArr((hashArr) => [...hashArr, hashtag])
          setHashtag('')
        }
      }
    },
    [hashtag]
  )
```

구조가

```
          <div className="HashWrap" css={hashDivrap}>
            <input
              className="HashInput"
              type="text"
              value={hashtag}
              onChange={onChangeHashtag}
              onKeyUp={onKeyUp}
              placeholder="해시태그 입력"
            />
         </div>
```

로 되어 있기 때문, 추가적으로 공부하여 velog 처럼 구현될 수 있도록 수정이 필요함

## 결과물 (2차)


https://user-images.githubusercontent.com/54658162/131502792-10eb93b1-6998-4736-a58b-520310786105.mov

[feat: 클릭 이벤트 발생 시 배열 state 관리/ onSubmit 성공시 해시태그 제거 완료](https://github.com/MIC-TEAM/wellseecoding-front/commit/539eea2dc20bb262420184f653b00a3db78ddf3a)

## 현주님!

백엔드 콜백 주소 변경을 메인 브랜치에 적용하기위해 pr 올립니다!
아직 로그인 토큰 관련 이슈가 마무리 되지 않아 엔드 포인트를 프론트의 alert() 메서드를 통해 관리하고 있습니다
후에 서버쪽 도메인으로 변경 및 리듀서 / 리덕스 함수 작성은 다른 이슈를 생성하여 작업하도록 하겠습니다

## 레퍼런스

[MDN Array.prototype.filter](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
[MDN spread operator](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Operators/Spread_syntax)
[키보드 키코드](https://blog.outsider.ne.kr/322)
[velog, useState를 사용해서 배열에 값 추가하기](https://velog.io/@summer_luna_0/reactuseState%EC%82%AC%EC%9A%A9%ED%95%B4%EC%84%9C-%EB%B0%B0%EC%97%B4%EC%97%90-%EA%B0%92-%EC%B6%94%EA%B0%80%ED%95%98%EA%B8%B0.-a.k.a-TODOLIST)